### PR TITLE
fix: Enhance autocomplete and fix editor bugs

### DIFF
--- a/Packages/src/Runtime/Scripts/Core/CodeEditor.cs
+++ b/Packages/src/Runtime/Scripts/Core/CodeEditor.cs
@@ -361,9 +361,6 @@ namespace C2M.CodeEditor
 
         private void ProcessCodeComplete(string text)
         {
-            if (isRemoved)
-                return;
-
             Vector3 caretWorldPosition = GetCaretWorldPosition();
             codeAutoComplete.UpdateCompletePosition(caretWorldPosition);
             codeAutoComplete.UpdateSuggestions(text, caretPosition);

--- a/Packages/src/Runtime/Scripts/Core/CodeEditor.cs
+++ b/Packages/src/Runtime/Scripts/Core/CodeEditor.cs
@@ -361,6 +361,9 @@ namespace C2M.CodeEditor
 
         private void ProcessCodeComplete(string text)
         {
+            if (isRemoved && !codeAutoComplete.IsShow)
+                return;
+
             Vector3 caretWorldPosition = GetCaretWorldPosition();
             codeAutoComplete.UpdateCompletePosition(caretWorldPosition);
             codeAutoComplete.UpdateSuggestions(text, caretPosition);

--- a/Packages/src/Runtime/Scripts/Core/CodeEditor.cs
+++ b/Packages/src/Runtime/Scripts/Core/CodeEditor.cs
@@ -146,7 +146,7 @@ namespace C2M.CodeEditor
                 Redo();
             }
 
-            if (inputActionsManager.IsInputEnter)
+            if (inputActionsManager.IsInputEnter && !codeAutoComplete.IsShow)
             {
                 autoIndent.GetAutoIndentText(text, caretPosition);
             }
@@ -210,10 +210,7 @@ namespace C2M.CodeEditor
             if (inputActionsManager.IsInputPaste)
                 return;
 
-            if (!string.IsNullOrEmpty(newText))
-            {
-                newText = newText.Replace("\r\n", "\n").Replace('\r', '\n');
-            }
+            newText = ReplaceLineSymbol(newText);
 
             if (string.IsNullOrEmpty(newText))
             {
@@ -384,6 +381,16 @@ namespace C2M.CodeEditor
             float size = viewportRect.width / textComponent.preferredWidth;
 
             horizontalScrollBar.size = size;
+        }
+
+        private string ReplaceLineSymbol(string target)
+        {
+            if (!string.IsNullOrEmpty(target))
+            {
+               return target.Replace("\r\n", "\n").Replace('\r', '\n');
+            }
+
+            return target;
         }
 
         private void UpdateLineTextRect()
@@ -560,6 +567,7 @@ namespace C2M.CodeEditor
         private void UpdateText(string text, bool isSelectionAndInputKey)
         {
             int preUpdateTextStringPosition = stringPosition;
+            text = ReplaceLineSymbol(text);
 
             this.text = text;
             prevText = text;

--- a/Packages/src/Samples~/Prefabs/CodeEditor.prefab
+++ b/Packages/src/Samples~/Prefabs/CodeEditor.prefab
@@ -982,11 +982,11 @@ RectTransform:
   - {fileID: 3580206026843699795}
   m_Father: {fileID: 3901076949835288040}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: -110, y: 0}
-  m_SizeDelta: {x: 110.22, y: 483}
-  m_Pivot: {x: 0, y: 1}
+  m_SizeDelta: {x: 110.22, y: 0.000061035}
+  m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &7319344364117807040
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1766,7 +1766,7 @@ MonoBehaviour:
   m_HideSoftKeyboard: 0
   m_CharacterValidation: 0
   m_RegexValue: 
-  m_GlobalPointSize: 55
+  m_GlobalPointSize: 40
   m_CharacterLimit: 0
   m_OnEndEdit:
     m_PersistentCalls:

--- a/Packages/src/Samples~/SampleScene/SampleScene.unity
+++ b/Packages/src/Samples~/SampleScene/SampleScene.unity
@@ -673,11 +673,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3901076949835288040, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 490.5979
+      value: 1126.5104
       objectReference: {fileID: 0}
     - target: {fileID: 3901076949835288040, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 483
+      value: 793.5612
       objectReference: {fileID: 0}
     - target: {fileID: 3901076949835288040, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
       propertyPath: m_LocalPosition.x
@@ -709,11 +709,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3901076949835288040, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -254.70605
+      value: -24.0652
       objectReference: {fileID: 0}
     - target: {fileID: 3901076949835288040, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 8.5
+      value: 109.8752
       objectReference: {fileID: 0}
     - target: {fileID: 3901076949835288040, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -731,6 +731,22 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 4291b765527fc074c94dc813bc2855a2, type: 3}
+    - target: {fileID: 4487337900557481221, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4487337900557481221, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4487337900557481221, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0.000061035
+      objectReference: {fileID: 0}
+    - target: {fileID: 4487337900557481221, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5540353020361545486, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
       propertyPath: m_Sprite
       value: 
@@ -742,6 +758,14 @@ PrefabInstance:
     - target: {fileID: 5682412358145169118, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7539236193290722079, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 32
+      objectReference: {fileID: 0}
+    - target: {fileID: 8300283010524465626, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
+      propertyPath: m_GlobalPointSize
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 8300283010524465626, guid: 99eec05a963dc154ca69b6ef64bd0ad4, type: 3}
       propertyPath: m_CustomCaretColor


### PR DESCRIPTION
fix: Scale line number text on editor resize

fix: Correct autocomplete input and normalize line endings
- Resolves a bug where autocompletion using the Enter key would fail in specific scenarios.
- Unifies newline characters to a consistent format during text updates to prevent cross-platform inconsistencies.

feat: Refresh suggestions on character deletion
- Updates the autocomplete suggestion list when a character is deleted

fix: Only refresh suggestions on deletion when autocomplete active
- Prevents the autocomplete list from appearing unexpectedly when deleting text. The list now only updates on deletion if it was already visible.